### PR TITLE
Make sure the .gitignore template does not get .npmignored

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 ./src
+!template/.gitignore


### PR DESCRIPTION
npm automatically ignores .gitignore files when packing a package to the registry. Because of that the result of `npm init managed-component` was missing the .gitignore file. I've added a manual override for the templates/.gitignore file it's forced to be included